### PR TITLE
Add working pdftk link for MacOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 remove-pdf-watermark
 ====================
 
-Short script for removing watermarks from PDF files. Requires [pdftk](http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/).
+Short script for removing watermarks from PDF files. Requires [pdftk](http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/). Users of MacOS El Capitan (10.11) and above should download [pdftk server version 2.02](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg).
 
 Tested only lightly. Works by using pdftk to uncompress the PDF, scans through the file for the supplied watermark text 
 and removes the closest containing object, then recompresses with pdftk. Sometimes a watermark might not be represented as


### PR DESCRIPTION
The version of pdftk server linked on the main PDF Labs page does not work with MacOS 10.11 and above. There is an official working version but the pdftk site fails to include a link to it. See https://stackoverflow.com/questions/39750883/pdftk-hanging-on-macos-sierra